### PR TITLE
switch to official NaughtyAttributes branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ An awesome list of Git repositories for Unity that support Unity Package Manager
 
 | Name                                   	| URL                                                           	|
 |----------------------------------------	|---------------------------------------------------------------	|
-| Eflatun.Inspector		 					| https://github.com/starikcetin/Eflatun.Inspector					|
-| NaughtyAttributes (fork)               	| https://github.com/JimmyCushnie/NaughtyAttributes             	|
+| Eflatun.Inspector		 					          | https://github.com/starikcetin/Eflatun.Inspector				      	|
+| NaughtyAttributes                     	| https://github.com/dbrizov/NaughtyAttributes/tree/upm          	|
 | Scene Reference (import from gist)     	| https://github.com/starikcetin/unity-scene-reference          	|
-| Serializable Callback                   	| https://github.com/MeikelLP/SerializableCallback                	|
+| Serializable Callback                   | https://github.com/MeikelLP/SerializableCallback                |
 | Serializable Dictionary (fork)         	| https://github.com/starikcetin/Unity-SerializableDictionary   	|
-| type-inspector                          	| https://github.com/k0dep/type-inspector                         	|
+| type-inspector                          | https://github.com/k0dep/type-inspector                         |
 
 
 ## UI


### PR DESCRIPTION
The official NaughtyAttributes repo got UPM support, so we no longer need my fork for it.