### PR TITLE
Removed k0dep & Wolfoso's Newtonsoft.Json packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ An awesome list of Git repositories for Unity that support Unity Package Manager
 | InterSUCC                                 | https://github.com/JimmyCushnie/InterSUCC                                             |
 | Json RPC                                  | https://github.com/k0dep/Unity-Json-Rpc                                               |
 | Newtonsoft.Json (PixelWizards)            | https://github.com/PixelWizards/com.newtonsoft.json                                   |
-| Newtonsoft.Json (k0dep)                   | https://github.com/k0dep/Newtonsoft.Json                                              |
-| Newtonsoft.Json (Wolfoso)                 | https://github.com/Wolfoso/NewtonsoftJson                                             |
 | PersistentData                            | https://github.com/JimmyCushnie/PersistentData                                        |
 | SUCC                                      | http://www.succ.software/                                                             |
 


### PR DESCRIPTION
Both k0dep's and Wolfoso's repos has just taken ParentElement's JSON .NET and republished them to use in UPM. This violates the Unity Assets Store EULA as the packages has not been publicly granted permission by neither Unity nor ParentElement. <https://unity3d.com/legal/as_terms>

Also debatable if to add a *\*ONLY FOR UNITY INTERNAL USE\** footnote to PixelWizards Newtonsoft.Json package, as it's not meant to be used by end users.