### PR TITLE
Add UniLWP.Droid

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An awesome list of Git repositories for Unity that support Unity Package Manager
 |-----------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
 |[Eflatun.WebView                           ](https://github.com/starikcetin/Eflatun.WebView                                       )| WebView for Unity.                                                                                                    |
 |[Outline-Effect                            ](https://github.com/cakeslice/Outline-Effect                                          )| Draw colored outlines around objects in 3D                                                                            |
+|[UniLWP.Droid                              ](https://github.com/JustinFincher/UniLWP.Droid.Package.Free                           )| Drop-in aar for making Android live wallpapers using Unity                                                            |
 
 
 ## Code

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An awesome list of Git repositories for Unity that support Unity Package Manager
 |-----------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
 |[Eflatun.WebView                           ](https://github.com/starikcetin/Eflatun.WebView                                       )| WebView for Unity.                                                                                                    |
 |[Outline-Effect                            ](https://github.com/cakeslice/Outline-Effect                                          )| Draw colored outlines around objects in 3D                                                                            |
-|[UniLWP.Droid                              ](https://github.com/JustinFincher/UniLWP.Droid.Package.Free                           )| Drop-in aar for making Android live wallpapers using Unity                                                            |
+|[UniLWP.Droid                              ](https://github.com/JustinFincher/UniLWP.Droid.Package.Free                           )| Drop-in aar for making Android live wallpapers using Unity (Limited version)                                          |
 
 
 ## Code


### PR DESCRIPTION
This is a pull request for adding UniLWP.Droid upm package ([Repo Link](https://github.com/JustinFincher/UniLWP.Droid.Package.Free)).   

FYI: UniLWP.Droid is an Android plugin that replaces the default Activity implementation in the Unity jar file with a customized Activity subclass that supports switching Surface from and to WallpaperServices.

Files changed:
```
README.md
```